### PR TITLE
Multiple closing tag types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: "ubuntu-latest", target: "i686-unknown-linux-gnu", toolchain: "stable" }
           - { os: "ubuntu-latest", target: "x86_64-unknown-linux-gnu", toolchain: "stable" }
           - { os: "ubuntu-latest", target: "x86_64-unknown-linux-gnu", toolchain: "beta"}
           - { os: "ubuntu-latest", target: "x86_64-unknown-linux-gnu", toolchain: "nightly"}

--- a/README.md
+++ b/README.md
@@ -89,10 +89,18 @@ log.info("<blue><on bright red> This text is blue on a bright red background</> 
 
 ###### Scroll down for a full list of keys if you're not feeling confident in your ability to name colors. It happens.
 
+
+### Resetting
 You've probably seen the `</>` tag in the above logs. It's not there to
 _"close the previously opened tag"_ no no. You can open as many tags as you want
-and only use `</>` once, it's just the _"reset color to default"_ tag, You might
+and only use `</>` once, it's just the _"reset everything to default"_ tag, You might
 decide you don't ever want to use it. It's up to you.
+
+However, resetting everything to default might not be what you want. Most of the time
+it'll be enough, but for those times when it isn't there are a few other tags such as:
+
+* `<///>` only resets background
+* `<//>` only reset foreground
 
 
 ## Color keys
@@ -115,7 +123,15 @@ or use underlines(`_`) or dashes(`-`) instead if you wish.
 `on bright magenta`, `on bright white`
 
 #### Styles
-`bold`, `underline`, `dimmed`, `italic` 
+Styles are a bit different, they all have their usual keys, the long and painful to write ones. But they 
+also have shorthand keys (in parenthesis).
+
+`bold`(`b`), `underline`(`u`), `dimmed`(`d`), `italic`(`i`)
+
+And while they all may reset using one of the reset keys above, if you're looking to turn off a specific
+style you've opened, you can just use the exact same key but with a slash `/` in front of it.
+
+Example: `<bold>` gets closed by `</bold>` 
 
 #### Icons
 `info`, `cross`, `warn`, `tick`, `heart`

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ or use underlines(`_`) or dashes(`-`) instead if you wish.
 `on bright magenta`, `on bright white`
 
 #### Styles
+`bold`(`b`), `underline`(`u`), `dimmed`(`d`), `italic`(`i`)
+
 Styles are a bit different, they all have their usual keys, the long and painful to write ones. But they 
 also have shorthand keys (in parenthesis).
-
-`bold`(`b`), `underline`(`u`), `dimmed`(`d`), `italic`(`i`)
 
 And while they all may reset using one of the reset keys above, if you're looking to turn off a specific
 style you've opened, you can just use the exact same key but with a slash `/` in front of it.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ decide you don't ever want to use it. It's up to you.
 However, resetting everything to default might not be what you want. Most of the time
 it'll be enough, but for those times when it isn't there are a few other tags such as:
 
-* `<///>` only resets background
-* `<//>` only reset foreground
+* `<///>` only resets the background
+* `<//>` only reset the foreground
 
 
 ## Color keys

--- a/src/formatter/color.rs
+++ b/src/formatter/color.rs
@@ -19,7 +19,11 @@ pub enum Color {
     BrightMagenta,
     BrightCyan,
     BrightWhite,
+
+    BackgroundReset,
+    ForegroundReset,
     Reset,
+
     None // So we can check if its a color or not
     // In case there's HTML in the logs
 }
@@ -45,7 +49,11 @@ impl Color {
             Color::BrightMagenta => 95,
             Color::BrightCyan => 96,
             Color::BrightWhite => 97,
+
+            Color::ForegroundReset => 39,
+            Color::BackgroundReset => 49,
             Color::Reset => 0,
+
             Color::None => 0
         }
     }
@@ -69,7 +77,11 @@ impl Color {
             Color::BrightMagenta => 105,
             Color::BrightCyan => 106,
             Color::BrightWhite => 107,
+
+            Color::ForegroundReset => 39,
+            Color::BackgroundReset => 49,
             Color::Reset => 0,
+
             Color::None => 0
         }
     }
@@ -108,7 +120,12 @@ impl FromStr for Color {
             "bright magenta" => Ok(Color::BrightMagenta),
             "bright cyan" => Ok(Color::BrightCyan),
             "bright white" => Ok(Color::BrightWhite),
+
+            // Different resets for each color or everything
+            "///" => Ok(Color::BackgroundReset),
+            "//" => Ok(Color::ForegroundReset),
             "/" => Ok(Color::Reset),
+
             _ => Err(())
         }
     }

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -4,9 +4,17 @@ use std::str::FromStr;
 
 pub enum Style {
     Bold,
+    BoldReset,
+
     Italic,
+    ItalicReset,
+
     Underline,
+    UnderlineReset,
+
     Dimmed,
+    DimmedReset,
+
     None
 }
 
@@ -16,9 +24,17 @@ impl Style {
     pub fn get_value(&self) -> u8 {
         match self {
             Style::Bold => 1,
+            Style::BoldReset => 22,
+
             Style::Dimmed => 2,
+            Style::DimmedReset => 22,
+
             Style::Italic => 3,
+            Style::ItalicReset => 23,
+
             Style::Underline => 4,
+            Style::UnderlineReset => 24,
+
             Style::None => 0
         }
     }
@@ -41,10 +57,18 @@ impl FromStr for Style {
         let src = s.to_lowercase();
 
         match src.as_ref() {
-            "bold" => Ok(Style::Bold),
-            "italic" => Ok(Style::Italic),
-            "underline" => Ok(Style::Underline),
-            "dimmed" => Ok(Style::Dimmed),
+            "bold" | "b" => Ok(Style::Bold),
+            "/b" => Ok(Style::BoldReset),
+
+            "dimmed" | "d" => Ok(Style::Dimmed),
+            "/d" => Ok(Style::DimmedReset),
+
+            "italic" | "i" => Ok(Style::Italic),
+            "/i" => Ok(Style::ItalicReset),
+
+            "underline" | "u" => Ok(Style::Underline),
+            "/u" => Ok(Style::UnderlineReset),
+
             _ => Err(())
         }
     }

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -58,16 +58,16 @@ impl FromStr for Style {
 
         match src.as_ref() {
             "bold" | "b" => Ok(Style::Bold),
-            "/b" => Ok(Style::BoldReset),
+            "/bold" | "/b" => Ok(Style::BoldReset),
 
             "dimmed" | "d" => Ok(Style::Dimmed),
-            "/d" => Ok(Style::DimmedReset),
+            "/dimmed"| "/d" => Ok(Style::DimmedReset),
 
             "italic" | "i" => Ok(Style::Italic),
-            "/i" => Ok(Style::ItalicReset),
+            "/italic" | "/i" => Ok(Style::ItalicReset),
 
             "underline" | "u" => Ok(Style::Underline),
-            "/u" => Ok(Style::UnderlineReset),
+            "/underline" | "/u" => Ok(Style::UnderlineReset),
 
             _ => Err(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,17 @@
 //! See [the README](https://github.com/SirTheViking/logger/blob/master/README.md) for a full list of keys
 //! if you're not feeling confident in your ability to name colors. It happens.
 //!
+//! ### Resetting
 //! You've probably seen the `</>` tag in the above logs. It's not there to
 //! _"close the previously opened tag"_ no no. You can open as many tags as you want
-//! and only use `</>` once, it's just the _"reset color to default"_ tag, You might
+//! and only use `</>` once, it's just the _"reset everything to default"_ tag, You might
 //! decide you don't ever want to use it. It's up to you.
+
+//! However, resetting everything to default might not be what you want. Most of the time
+//! it'll be enough, but for those times when it isn't there are a few other tags such as:
+
+//! * `<///>` only resets the background
+//! * `<//>` only reset the foreground
 #![warn(missing_docs)]
 
 #[cfg(feature = "timestamps")]


### PR DESCRIPTION
Solutions:

Styles:
* Each tag has a closing tag of its own `<bold> </bold>`
* Each tag has a shorthand format `<b> </b>` // Still bold

Colors:
* Colors can now be reset individually (background or foreground)
* The `<//>` tag resets the foreground
* The `<///>` tag resets the background


Not sure about the color reset tags, yeah they work, but they don't feel like the best looking things...